### PR TITLE
Simplify file serving from local or remote

### DIFF
--- a/files/backblaze.go
+++ b/files/backblaze.go
@@ -140,10 +140,6 @@ func (bp *BackblazeProvider) GetDirectory(path string) Directory {
 	return finalDir
 }
 
-func (bp *BackblazeProvider) FilePath(path string) string {
-	return ""
-}
-
 func (bp *BackblazeProvider) SendFile(path string, w io.Writer) (stream io.Reader, contenttype string, err error) {
 	client := &http.Client{}
 	// Get bucket name >:(

--- a/files/fileprovider.go
+++ b/files/fileprovider.go
@@ -38,7 +38,6 @@ type FileInfo struct {
 type FileProviderInterface interface {
 	Setup(args map[string]string) (ok bool)
 	GetDirectory(path string) (directory Directory)
-	FilePath(path string) (realpath string)
 	SendFile(path string, writer io.Writer) (stream io.Reader, contenttype string, err error)
 	SaveFile(file io.Reader, filename string, path string) (ok bool)
 	ObjectInfo(path string) (exists bool, isDir bool, location string)
@@ -56,11 +55,6 @@ func (f FileProvider) Setup(args map[string]string) bool {
 // GetDirectory fetches a directory's contents.
 func (f FileProvider) GetDirectory(path string) Directory {
 	return Directory{}
-}
-
-// FilePath returns the path to the file, whether it be a URL or local file path.
-func (f FileProvider) FilePath(path string) string {
-	return ""
 }
 
 // RemoteFile will bypass http.ServeContent() and instead write directly to the response.

--- a/files/fileprovider.go
+++ b/files/fileprovider.go
@@ -39,7 +39,7 @@ type FileProviderInterface interface {
 	Setup(args map[string]string) (ok bool)
 	GetDirectory(path string) (directory Directory)
 	FilePath(path string) (realpath string)
-	RemoteFile(path string, writer io.Writer)
+	SendFile(path string, writer io.Writer) (stream io.Reader, contenttype string, err error)
 	SaveFile(file io.Reader, filename string, path string) (ok bool)
 	ObjectInfo(path string) (exists bool, isDir bool, location string)
 	CreateDirectory(path string) (ok bool)
@@ -64,7 +64,7 @@ func (f FileProvider) FilePath(path string) string {
 }
 
 // RemoteFile will bypass http.ServeContent() and instead write directly to the response.
-func (f FileProvider) RemoteFile(path string, writer io.Writer) {
+func (f FileProvider) SendFile(path string, writer io.Writer) (stream io.Reader, contenttype string, err error) {
 	return
 }
 

--- a/files/files_test.go
+++ b/files/files_test.go
@@ -24,10 +24,6 @@ func TestFileProvider(t *testing.T) {
 		t.Errorf("Default FileProvider GetDirectory() files returned %v, expected none.", getdirectory.Files)
 	}
 
-	filepath := fp.FilePath(""); if filepath != "" {
-		t.Errorf("Default FileProvider FilePath() %v, expected nothing.", filepath)
-	}
-
 	savefile := fp.SaveFile(nil, "", ""); if savefile != false {
 		t.Errorf("Default FileProvider SaveFile() attempted to save a file.")
 	}
@@ -85,10 +81,6 @@ func TestDiskProvider(t *testing.T) {
 
 	getdirectory := dp.GetDirectory(""); if len(getdirectory.Files) != 1 {
 		t.Errorf("DiskProvider GetDirectory() files returned %v, expected 1.", getdirectory.Files)
-	}
-
-	filepath := dp.FilePath("testing.txt"); if filepath !=  DISK_TESTING_GROUNDS + "/testing.txt"{
-		t.Errorf("DiskProvider FilePath() returned %v, expected path.", filepath)
 	}
 
  	testfile := bytes.NewReader([]byte("second test file!"))

--- a/router/filerouter.go
+++ b/router/filerouter.go
@@ -3,14 +3,14 @@ package router
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gmemstr/nas/files"
-	"github.com/gorilla/mux"
+	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"sort"
 	"strings"
-	"time"
+
+	"github.com/gmemstr/nas/files"
+	"github.com/gorilla/mux"
 )
 
 func handleProvider() handler {
@@ -29,7 +29,7 @@ func handleProvider() handler {
 					StatusCode: http.StatusInternalServerError,
 				}
 			}
-			ok, isDir, location := provider.ObjectInfo(filename)
+			ok, isDir, _ := provider.ObjectInfo(filename)
 			if !ok {
 				return &httpError{
 					Message:    fmt.Sprintf("error locating file %s\n", filename),
@@ -49,27 +49,25 @@ func handleProvider() handler {
 				}
 				w.Write(data)
 				return nil
-			}
+			} else {
+				stream, contenttype, err := provider.SendFile(filename, w)
 
-			// If the file is local, attempt to use http.ServeContent for correct headers.
-			if location == files.FileIsLocal {
-				rp := provider.FilePath(filename)
-				if rp != "" {
-					f, err := os.Open(rp)
-					if err != nil {
-						return &httpError{
-							Message:    fmt.Sprintf("error opening file %s\n", rp),
-							StatusCode: http.StatusInternalServerError,
-						}
+				if err != nil {
+					return &httpError{
+						Message:    fmt.Sprintf("error finding file %s\n", vars["file"]),
+						StatusCode: http.StatusNotFound,
 					}
-					http.ServeContent(w, r, filename, time.Time{}, f)
+				}
+				w.Header().Set("Content-Type", contenttype)
+				_, err = io.Copy(w, stream)
+				if err != nil {
+					return &httpError{
+						Message:    fmt.Sprintf("unable to write %s\n", vars["file"]),
+						StatusCode: http.StatusBadGateway,
+					}
 				}
 			}
-			// If the file is remote, then delegate the writing to the response to the provider.
-			// This isn't a great workaround, but avoids caching the whole file in mem or on disk.
-			if location == files.FileIsRemote {
-				provider.RemoteFile(filename, w)
-			}
+
 			return nil
 		}
 


### PR DESCRIPTION
Prior, we would decide how to serve a file based on whether it was local
or remote at a router level. This moves everything to an io.Copy call in
the router with the Provider returning an io.Reader.

resolves #12 
